### PR TITLE
Update README grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mcp-fabric-rest
 
-MCP Server for Microsoft Fabric Rest API's to be used primarily in Visual Studio Code and Codex.
+MCP server for Microsoft Fabric REST APIs used primarily with Visual Studio Code and Codex.
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- fix grammar in README about REST APIs

## Testing
- `pytest -m compliance` *(fails: command not found)*
- `bandit -r mcp_fabric_rest` *(fails: command not found)*
- `mypy --strict mcp_fabric_rest`
