### PR TITLE
Add pytest test for server registration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ python = ">=3.11"
 [tool.poetry.scripts]
 mcp-fabric-rest = "mcp_fabric.main:main"
 
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.0"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,6 @@
+import mcp_fabric
+
+
+def test_server_registered():
+    assert "mcp-fabric-rest" in mcp_fabric.SERVERS
+


### PR DESCRIPTION
## Summary
- add a pytest dev dependency
- test that the main server is registered

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*