### PR TITLE
Add REST server mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,13 @@ The server exposes a REST interface that acts as a bridge between the Microsoft 
    ```bash
    poetry run python -m mcp_fabric.main --stdio
    ```
-   Optional REST and gRPC façades can be enabled with flags:
+3. Start the REST server:
    ```bash
-   poetry run python -m mcp_fabric.main --stdio --rest --grpc
+   poetry run python -m mcp_fabric.main --rest
+   ```
+   You can combine flags to run both STDIO and REST modes:
+   ```bash
+   poetry run python -m mcp_fabric.main --stdio --rest
    ```
 
 With REST enabled the service listens on `http://localhost:3000`.

--- a/mcp_fabric/main.py
+++ b/mcp_fabric/main.py
@@ -4,18 +4,72 @@ from __future__ import annotations
 
 import argparse
 import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 
 def run_server() -> None:
-    """Placeholder server implementation."""
+    """Start the server in STDIO mode."""
     print("mcp-fabric-rest server started", flush=True)
+
+
+class RestHandler(BaseHTTPRequestHandler):
+    """Simple REST request handler."""
+
+    def _send_json(self, code: int, body: str) -> None:
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(body.encode("utf-8"))
+
+    def log_message(self, format: str, *args: str) -> None:  # noqa: D401
+        """Silence default logging."""
+        return
+
+    def do_GET(self) -> None:  # noqa: D401
+        """Handle GET requests."""
+        if self.path == "/health":
+            self._send_json(200, '{"status": "ok"}')
+        elif self.path == "/v1/workspaces":
+            self._send_json(200, "[]")
+        elif self.path == "/v1/artifacts":
+            self._send_json(200, "[]")
+        else:
+            self.send_error(404)
+
+    def do_POST(self) -> None:  # noqa: D401
+        """Handle POST requests."""
+        if self.path in {"/v1/workspaces", "/v1/artifacts"}:
+            self._send_json(201, "{}")
+        else:
+            self.send_error(404)
+
+
+def run_rest_server(host: str = "localhost", port: int = 3000) -> None:
+    """Start a REST HTTP server."""
+    server = HTTPServer((host, port), RestHandler)
+    print(f"REST server listening on http://{host}:{port}", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
 
 
 def main(argv: list[str] | None = None) -> None:
     """CLI entry point."""
     parser = argparse.ArgumentParser(description="MCP Fabric REST server")
     parser.add_argument("--stdio", action="store_true", help="run server using stdio")
+    parser.add_argument("--rest", action="store_true", help="run REST HTTP server")
     args = parser.parse_args(argv)
+
+    threads: list[threading.Thread] = []
+
+    if args.rest:
+        thread = threading.Thread(target=run_rest_server, daemon=args.stdio)
+        thread.start()
+        threads.append(thread)
 
     if args.stdio:
         run_server()
@@ -25,7 +79,12 @@ def main(argv: list[str] | None = None) -> None:
                 print(line.rstrip(), flush=True)
         except KeyboardInterrupt:
             pass
-    else:
+
+    if args.rest and not args.stdio:
+        # Wait for the REST server thread when running alone
+        threads[0].join()
+
+    if not args.rest and not args.stdio:
         parser.print_help()
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,52 @@
+import http.client
+import threading
+
 import mcp_fabric
+from mcp_fabric.main import RestHandler, HTTPServer
 
 
 def test_server_registered():
     assert "mcp-fabric-rest" in mcp_fabric.SERVERS
 
+
+def _start_server():
+    server = HTTPServer(("localhost", 0), RestHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+def test_health_endpoint():
+    server, thread = _start_server()
+    port = server.server_address[1]
+    conn = http.client.HTTPConnection("localhost", port)
+    conn.request("GET", "/health")
+    response = conn.getresponse()
+    body = response.read().decode()
+    conn.close()
+    server.shutdown()
+    thread.join()
+    assert response.status == 200
+    assert body == '{"status": "ok"}'
+
+
+def test_workspaces_and_artifacts():
+    server, thread = _start_server()
+    port = server.server_address[1]
+    conn = http.client.HTTPConnection("localhost", port)
+
+    conn.request("GET", "/v1/workspaces")
+    resp = conn.getresponse()
+    body = resp.read().decode()
+    assert resp.status == 200
+    assert body == "[]"
+
+    conn.request("POST", "/v1/artifacts")
+    resp = conn.getresponse()
+    body = resp.read().decode()
+    assert resp.status == 201
+    assert body == "{}"
+
+    conn.close()
+    server.shutdown()
+    thread.join()


### PR DESCRIPTION
## Summary
- allow running the server with a new `--rest` flag
- implement a basic HTTP server with `/health`, `/v1/workspaces`, and `/v1/artifacts` routes
- document usage of the REST flag in README
- test HTTP endpoints

## Testing
- `poetry run pytest -q`