### PR TITLE
Remove grpc flag mention from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ The server exposes a REST interface that acts as a bridge between the Microsoft 
    ```bash
    poetry run python -m mcp_fabric.main --stdio
    ```
-   Optional REST and gRPC façades can be enabled with flags:
+   The REST façade can be enabled with the following flag:
    ```bash
-   poetry run python -m mcp_fabric.main --stdio --rest --grpc
+   poetry run python -m mcp_fabric.main --stdio --rest
    ```
 
 With REST enabled the service listens on `http://localhost:3000`.


### PR DESCRIPTION
## Summary
- remove gRPC flag reference from README since it's not implemented

## Testing
- `poetry run pytest -q`
- `poetry run python -m mcp_fabric.main --help | head -n 12`
