### PR TITLE
Add REST server routes and tests

### DIFF
--- a/mcp_fabric/main.py
+++ b/mcp_fabric/main.py
@@ -3,12 +3,65 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+
+class RESTRequestHandler(BaseHTTPRequestHandler):
+    """Simple HTTP request handler for the MCP Fabric REST API."""
+
+    server_version = "mcp-fabric-rest"
+
+    def _json_response(self, status: int, data: Any) -> None:
+        """Send a JSON response."""
+
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(data).encode())
+
+    def do_GET(self) -> None:  # noqa: D401
+        """Handle GET requests."""
+
+        if self.path == "/health":
+            self._json_response(200, {"status": "ok"})
+        elif self.path == "/v1/workspaces":
+            self._json_response(200, {"workspaces": []})
+        elif self.path == "/v1/artifacts":
+            self._json_response(200, {"artifacts": []})
+        else:
+            self.send_error(404)
+
+    def do_POST(self) -> None:  # noqa: D401
+        """Handle POST requests."""
+
+        if self.path in {"/v1/workspaces", "/v1/artifacts"}:
+            # Consume the request body even though we don't use it
+            content_length = int(self.headers.get("Content-Length", 0))
+            if content_length:
+                self.rfile.read(content_length)
+            self._json_response(201, {"created": True})
+        else:
+            self.send_error(404)
+
+
+def create_server(host: str = "localhost", port: int = 3000) -> HTTPServer:
+    """Create the REST server instance."""
+
+    return HTTPServer((host, port), RESTRequestHandler)
 
 
 def run_server() -> None:
-    """Placeholder server implementation."""
+    """Run the MCP Fabric REST server."""
+
+    server = create_server()
     print("mcp-fabric-rest server started", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,4 +3,3 @@ import mcp_fabric
 
 def test_server_registered():
     assert "mcp-fabric-rest" in mcp_fabric.SERVERS
-

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,61 @@
+import json
+import threading
+import time
+from urllib import request
+
+import pytest
+
+from mcp_fabric.main import create_server
+
+
+@pytest.fixture(scope="module")
+def server():
+    srv = create_server()
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    time.sleep(0.1)
+    try:
+        yield srv
+    finally:
+        srv.shutdown()
+        thread.join()
+
+
+def _request(path: str, data: bytes | None = None, method: str = "GET"):
+    req = request.Request(f"http://localhost:3000{path}", data=data, method=method)
+    req.add_header("Content-Type", "application/json")
+    with request.urlopen(req) as resp:
+        body = resp.read()
+        return resp.status, json.loads(body)
+
+
+def test_health(server):
+    status, body = _request("/health")
+    assert status == 200
+    assert body == {"status": "ok"}
+
+
+def test_workspaces_get(server):
+    status, body = _request("/v1/workspaces")
+    assert status == 200
+    assert body == {"workspaces": []}
+
+
+def test_workspaces_post(server):
+    data = json.dumps({"name": "test"}).encode()
+    status, body = _request("/v1/workspaces", data=data, method="POST")
+    assert status == 201
+    assert body == {"created": True}
+
+
+def test_artifacts_get(server):
+    status, body = _request("/v1/artifacts")
+    assert status == 200
+    assert body == {"artifacts": []}
+
+
+def test_artifacts_post(server):
+    data = json.dumps({"name": "test"}).encode()
+    status, body = _request("/v1/artifacts", data=data, method="POST")
+    assert status == 201
+    assert body == {"created": True}


### PR DESCRIPTION
## Summary
- implement minimal HTTP server for REST API
- add fixture-based tests verifying all routes

## Testing
- `poetry run pytest -q`