### PR TITLE
Use dynamic port for tests

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,4 +1,5 @@
 import json
+import socket
 import threading
 import time
 from urllib import request
@@ -10,7 +11,11 @@ from mcp_fabric.main import create_server
 
 @pytest.fixture(scope="module")
 def server():
-    srv = create_server()
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("localhost", 0))
+        port = sock.getsockname()[1]
+
+    srv = create_server(port=port)
     thread = threading.Thread(target=srv.serve_forever, daemon=True)
     thread.start()
     time.sleep(0.1)
@@ -21,8 +26,10 @@ def server():
         thread.join()
 
 
-def _request(path: str, data: bytes | None = None, method: str = "GET"):
-    req = request.Request(f"http://localhost:3000{path}", data=data, method=method)
+def _request(server, path: str, data: bytes | None = None, method: str = "GET"):
+    req = request.Request(
+        f"http://localhost:{server.server_port}{path}", data=data, method=method
+    )
     req.add_header("Content-Type", "application/json")
     with request.urlopen(req) as resp:
         body = resp.read()
@@ -30,32 +37,32 @@ def _request(path: str, data: bytes | None = None, method: str = "GET"):
 
 
 def test_health(server):
-    status, body = _request("/health")
+    status, body = _request(server, "/health")
     assert status == 200
     assert body == {"status": "ok"}
 
 
 def test_workspaces_get(server):
-    status, body = _request("/v1/workspaces")
+    status, body = _request(server, "/v1/workspaces")
     assert status == 200
     assert body == {"workspaces": []}
 
 
 def test_workspaces_post(server):
     data = json.dumps({"name": "test"}).encode()
-    status, body = _request("/v1/workspaces", data=data, method="POST")
+    status, body = _request(server, "/v1/workspaces", data=data, method="POST")
     assert status == 201
     assert body == {"created": True}
 
 
 def test_artifacts_get(server):
-    status, body = _request("/v1/artifacts")
+    status, body = _request(server, "/v1/artifacts")
     assert status == 200
     assert body == {"artifacts": []}
 
 
 def test_artifacts_post(server):
     data = json.dumps({"name": "test"}).encode()
-    status, body = _request("/v1/artifacts", data=data, method="POST")
+    status, body = _request(server, "/v1/artifacts", data=data, method="POST")
     assert status == 201
     assert body == {"created": True}


### PR DESCRIPTION
## Summary
- start REST server on a free port for tests
- update request helper to use the server's port

## Testing
- `poetry run pytest -q`