### PR TITLE
Add CLI port option and subprocess test

### DIFF
--- a/mcp_fabric/main.py
+++ b/mcp_fabric/main.py
@@ -77,12 +77,19 @@ def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="MCP Fabric REST server")
     parser.add_argument("--stdio", action="store_true", help="run server using stdio")
     parser.add_argument("--rest", action="store_true", help="run REST HTTP server")
+    parser.add_argument(
+        "--port", type=int, default=3000, help="port for REST HTTP server"
+    )
     args = parser.parse_args(argv)
 
     threads: list[threading.Thread] = []
 
     if args.rest:
-        thread = threading.Thread(target=run_rest_server, daemon=args.stdio)
+        thread = threading.Thread(
+            target=run_rest_server,
+            kwargs={"port": args.port},
+            daemon=args.stdio,
+        )
         thread.start()
         threads.append(thread)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,10 @@
+import json
+import socket
+import subprocess
+import sys
+import time
+from urllib import request
+
 import http.client
 import threading
 
@@ -7,3 +14,38 @@ from mcp_fabric.main import RestHandler, HTTPServer
 
 def test_server_registered():
     assert "mcp-fabric-rest" in mcp_fabric.SERVERS
+
+
+def test_cli_rest_server_health():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("localhost", 0))
+        port = sock.getsockname()[1]
+
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "mcp_fabric.main", "--rest", "--port", str(port)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    try:
+        for _ in range(20):
+            try:
+                with request.urlopen(f"http://localhost:{port}/health") as resp:
+                    body = resp.read()
+                    assert resp.status == 200
+                    assert json.loads(body) == {"status": "ok"}
+                    break
+            except Exception:
+                if proc.poll() is not None:
+                    out, err = proc.communicate()
+                    raise AssertionError(f"server exited\nstdout: {out}\nstderr: {err}")
+                time.sleep(0.1)
+        else:
+            raise AssertionError("server did not start")
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()


### PR DESCRIPTION
## Summary
- allow specifying REST port via `--port`
- test CLI REST startup via subprocess

## Testing
- `poetry run pytest -q`