### PR TITLE
Add host option to REST server CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ The server exposes a REST interface that acts as a bridge between the Microsoft 
    poetry run python -m mcp_fabric.main --stdio
    ```
 
-   poetry run python -m mcp_fabric.main --stdio --rest
+   poetry run python -m mcp_fabric.main --stdio --rest --host 0.0.0.0
    ```
 
-With REST enabled the service listens on `http://localhost:3000`.
+With REST enabled the service listens on `http://localhost:3000` by default.
+Use `--host` and `--port` to change the bind address.
 
 ## Authentication
 

--- a/mcp_fabric/main.py
+++ b/mcp_fabric/main.py
@@ -58,13 +58,29 @@ class RestHandler(BaseHTTPRequestHandler):
 
 
 def create_server(host: str = "localhost", port: int = 3000) -> HTTPServer:
-    """Create the REST server instance."""
+    """Create the REST server instance.
+
+    Parameters
+    ----------
+    host:
+        Interface the HTTP server should bind to.
+    port:
+        Port the HTTP server should listen on.
+    """
 
     return HTTPServer((host, port), RestHandler)
 
 
 def run_rest_server(host: str = "localhost", port: int = 3000) -> None:
-    """Start a REST HTTP server."""
+    """Start a REST HTTP server.
+
+    Parameters
+    ----------
+    host:
+        Interface the HTTP server should bind to.
+    port:
+        Port the HTTP server should listen on.
+    """
     server = create_server(host, port)
     print(f"REST server listening on http://{host}:{port}", flush=True)
     try:
@@ -81,6 +97,11 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument(
         "--port", type=int, default=3000, help="port for REST HTTP server"
     )
+    parser.add_argument(
+        "--host",
+        default="localhost",
+        help="host interface for REST HTTP server",
+    )
     args = parser.parse_args(argv)
 
     threads: list[threading.Thread] = []
@@ -88,7 +109,7 @@ def main(argv: list[str] | None = None) -> None:
     if args.rest:
         thread = threading.Thread(
             target=run_rest_server,
-            kwargs={"port": args.port},
+            kwargs={"port": args.port, "host": args.host},
             daemon=args.stdio,
         )
         thread.start()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -49,3 +49,48 @@ def test_cli_rest_server_health():
             proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
             proc.kill()
+
+
+def test_cli_rest_server_custom_host():
+    host = "127.0.0.1"
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((host, 0))
+        port = sock.getsockname()[1]
+
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "mcp_fabric.main",
+            "--rest",
+            "--port",
+            str(port),
+            "--host",
+            host,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    try:
+        for _ in range(20):
+            try:
+                with request.urlopen(f"http://{host}:{port}/health") as resp:
+                    body = resp.read()
+                    assert resp.status == 200
+                    assert json.loads(body) == {"status": "ok"}
+                    break
+            except Exception:
+                if proc.poll() is not None:
+                    out, err = proc.communicate()
+                    raise AssertionError(f"server exited\nstdout: {out}\nstderr: {err}")
+                time.sleep(0.1)
+        else:
+            raise AssertionError("server did not start")
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()


### PR DESCRIPTION
## Summary
- allow setting REST server host via `--host`
- document the new option in README
- test server binds to a custom host

## Testing
- `poetry run pytest -q`