### PR TITLE
Handle 404s with JSON

### DIFF
--- a/mcp_fabric/main.py
+++ b/mcp_fabric/main.py
@@ -43,7 +43,7 @@ class RestHandler(BaseHTTPRequestHandler):
         elif self.path == "/v1/artifacts":
             self._send_json(200, {"artifacts": []})
         else:
-            self.send_error(404)
+            self._send_json(404, {"error": "not found"})
 
     def do_POST(self) -> None:  # noqa: D401
         """Handle POST requests."""
@@ -54,7 +54,7 @@ class RestHandler(BaseHTTPRequestHandler):
                 self.rfile.read(content_length)
             self._send_json(201, {"created": True})
         else:
-            self.send_error(404)
+            self._send_json(404, {"error": "not found"})
 
 
 def create_server(host: str = "localhost", port: int = 3000) -> HTTPServer:

--- a/tests/test_run_server.py
+++ b/tests/test_run_server.py
@@ -2,7 +2,7 @@ import json
 import socket
 import threading
 import time
-from urllib import request
+from urllib import request, error
 
 import pytest
 
@@ -31,9 +31,13 @@ def _request(server, path: str, data: bytes | None = None, method: str = "GET"):
         f"http://localhost:{server.server_port}{path}", data=data, method=method
     )
     req.add_header("Content-Type", "application/json")
-    with request.urlopen(req) as resp:
-        body = resp.read()
-        return resp.status, json.loads(body)
+    try:
+        with request.urlopen(req) as resp:
+            body = resp.read()
+            return resp.status, json.loads(body)
+    except error.HTTPError as exc:
+        body = exc.read()
+        return exc.code, json.loads(body)
 
 
 def test_run_server_health(run_srv):
@@ -66,3 +70,16 @@ def test_run_server_artifacts_post(run_srv):
     status, body = _request(run_srv, "/v1/artifacts", data=data, method="POST")
     assert status == 201
     assert body == {"created": True}
+
+
+def test_run_server_unknown_get(run_srv):
+    status, body = _request(run_srv, "/unknown")
+    assert status == 404
+    assert body == {"error": "not found"}
+
+
+def test_run_server_unknown_post(run_srv):
+    data = json.dumps({"foo": "bar"}).encode()
+    status, body = _request(run_srv, "/unknown", data=data, method="POST")
+    assert status == 404
+    assert body == {"error": "not found"}


### PR DESCRIPTION
## Summary
- return JSON for unknown endpoints
- update request helpers in tests to parse HTTP errors
- add coverage for missing routes

## Testing
- `poetry run pytest -q`