### PR TITLE
Add persistent lists for new API objects

### DIFF
--- a/mcp_fabric/main.py
+++ b/mcp_fabric/main.py
@@ -9,6 +9,12 @@ import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any
 
+# In-memory storage for created objects
+WORKSPACES: list[dict[str, Any]] = []
+"""Workspace records stored during runtime."""
+ARTIFACTS: list[dict[str, Any]] = []
+"""Artifact records stored during runtime."""
+
 
 def run_server(server: HTTPServer) -> None:
     """Run the given server until interrupted."""
@@ -39,19 +45,30 @@ class RestHandler(BaseHTTPRequestHandler):
         if self.path == "/health":
             self._send_json(200, {"status": "ok"})
         elif self.path == "/v1/workspaces":
-            self._send_json(200, {"workspaces": []})
+            self._send_json(200, {"workspaces": WORKSPACES})
         elif self.path == "/v1/artifacts":
-            self._send_json(200, {"artifacts": []})
+            self._send_json(200, {"artifacts": ARTIFACTS})
         else:
             self.send_error(404)
 
     def do_POST(self) -> None:  # noqa: D401
         """Handle POST requests."""
         if self.path in {"/v1/workspaces", "/v1/artifacts"}:
-            # Consume the request body even if we ignore it
             content_length = int(self.headers.get("Content-Length", 0))
+            payload: Any = {}
             if content_length:
-                self.rfile.read(content_length)
+                body = self.rfile.read(content_length)
+                try:
+                    payload = json.loads(body.decode("utf-8"))
+                except json.JSONDecodeError:
+                    self.send_error(400, "Invalid JSON")
+                    return
+
+            if self.path == "/v1/workspaces":
+                WORKSPACES.append(payload)
+            else:
+                ARTIFACTS.append(payload)
+
             self._send_json(201, {"created": True})
         else:
             self.send_error(404)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -5,11 +5,17 @@ from urllib import request
 
 import pytest
 
-from mcp_fabric.main import create_server
+from mcp_fabric.main import (
+    ARTIFACTS,
+    WORKSPACES,
+    create_server,
+)
 
 
 @pytest.fixture(scope="module")
 def server():
+    WORKSPACES.clear()
+    ARTIFACTS.clear()
     srv = create_server(port=0)
     thread = threading.Thread(target=srv.serve_forever, daemon=True)
     thread.start()
@@ -49,6 +55,10 @@ def test_workspaces_post(server):
     assert status == 201
     assert body == {"created": True}
 
+    status, body = _request(server, "/v1/workspaces")
+    assert status == 200
+    assert body == {"workspaces": [{"name": "test"}]}
+
 
 def test_artifacts_get(server):
     status, body = _request(server, "/v1/artifacts")
@@ -61,3 +71,7 @@ def test_artifacts_post(server):
     status, body = _request(server, "/v1/artifacts", data=data, method="POST")
     assert status == 201
     assert body == {"created": True}
+
+    status, body = _request(server, "/v1/artifacts")
+    assert status == 200
+    assert body == {"artifacts": [{"name": "test"}]}

--- a/tests/test_run_server.py
+++ b/tests/test_run_server.py
@@ -6,11 +6,18 @@ from urllib import request
 
 import pytest
 
-from mcp_fabric.main import create_server, run_server
+from mcp_fabric.main import (
+    ARTIFACTS,
+    WORKSPACES,
+    create_server,
+    run_server,
+)
 
 
 @pytest.fixture(scope="module")
 def run_srv():
+    WORKSPACES.clear()
+    ARTIFACTS.clear()
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("localhost", 0))
         port = sock.getsockname()[1]
@@ -54,6 +61,10 @@ def test_run_server_workspaces_post(run_srv):
     assert status == 201
     assert body == {"created": True}
 
+    status, body = _request(run_srv, "/v1/workspaces")
+    assert status == 200
+    assert body == {"workspaces": [{"name": "test"}]}
+
 
 def test_run_server_artifacts_get(run_srv):
     status, body = _request(run_srv, "/v1/artifacts")
@@ -66,3 +77,7 @@ def test_run_server_artifacts_post(run_srv):
     status, body = _request(run_srv, "/v1/artifacts", data=data, method="POST")
     assert status == 201
     assert body == {"created": True}
+
+    status, body = _request(run_srv, "/v1/artifacts")
+    assert status == 200
+    assert body == {"artifacts": [{"name": "test"}]}


### PR DESCRIPTION
## Summary
- keep workspace and artifact data in memory
- parse POST payloads and store them
- show stored data on GET requests
- verify POST+GET cycle in tests

## Testing
- `poetry run pytest -q`