### PR TITLE
Clean up stray text in tests

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -76,7 +76,6 @@ def test_artifacts_post(server):
     assert status == 201
     assert body == {"created": True}
 
-codex/implement-post-get-for-in-memory-storage
     status, body = _request(server, "/v1/artifacts")
     assert status == 200
     assert body == {"artifacts": [{"name": "test"}]}
@@ -93,4 +92,3 @@ def test_unknown_post(server):
     status, body = _request(server, "/unknown", data=data, method="POST")
     assert status == 404
     assert body == {"error": "not found"}
-main

--- a/tests/test_run_server.py
+++ b/tests/test_run_server.py
@@ -82,7 +82,6 @@ def test_run_server_artifacts_post(run_srv):
     assert status == 201
     assert body == {"created": True}
 
-codex/implement-post-get-for-in-memory-storage
     status, body = _request(run_srv, "/v1/artifacts")
     assert status == 200
     assert body == {"artifacts": [{"name": "test"}]}
@@ -99,4 +98,3 @@ def test_run_server_unknown_post(run_srv):
     status, body = _request(run_srv, "/unknown", data=data, method="POST")
     assert status == 404
     assert body == {"error": "not found"}
-main


### PR DESCRIPTION
## Summary
- remove stray codex markers from tests

## Testing
- `poetry run pytest -q`