### PR TITLE
Fix README STDIO commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ The server exposes a REST interface that acts as a bridge between the Microsoft 
 2. Start the server over STDIO:
    ```bash
    poetry run python -m mcp_fabric.main --stdio
-   ```
-
    poetry run python -m mcp_fabric.main --stdio --rest --host 0.0.0.0
    ```
 


### PR DESCRIPTION
## Summary
- fix README code block for server startup instructions

## Testing
- `poetry run pytest` *(fails: SyntaxError in tests)*
- `black README.md` *(fails: cannot parse)*
- `markdownlint README.md` *(fails: command not found)*